### PR TITLE
Github Actions CI Pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup component add rustfmt    
-      - run: cargo fmt -- --chec
+      - run: cargo fmt -- --check
       - run: rustup component add clippy
       - run: cargo -- -D warnings
       - run: rustc --version 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 on: 
   push: 
     branches:
-      [ "*" ]
+      - main
+      - 'feature/*'
 
 jobs:
   tests:
@@ -10,5 +11,6 @@ jobs:
     steps: 
       - uses: actions/checkout@v3
       - run: rustc --version 
+      - run: cargo build
       - run: cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           release_name: Release ${{ github.ref_name }}
       - name: Git tag version 
-        uses: pkgdeps/git-tag-action@v3
+        uses: pkgdeps/git-tag-action@v2
         with:
-          tag: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git_tag_prefix: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           git_tag_prefix: ${{ github.ref_name }}
           git_commit_sha: ${{ github.sha }}
+          github_repo: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: rustup component add rustfmt    
-      - run: cargo fmt --manifest-path Cargo.toml -- --check
+      # - run: cargo fmt --manifest-path Cargo.toml -- --check
+      - run: cargo fmt --manifest-path Cargo.toml -- --diff
       - run: rustup component add clippy
       - run: cargo clippy -- -D warnings
       - run: rustc --version 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,4 @@ jobs:
           version: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           git_tag_prefix: ${{ github.ref_name }}
+          git_commit_sha: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
-  metadata: read 
   id-token: write
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - run: rustup component add rustfmt    
       - run: cargo fmt --manifest-path Cargo.toml -- --check
       - run: rustup component add clippy
-      - run: cargo -- -D warnings
+      - run: cargo clippy -- -D warnings
       - run: rustc --version 
       - run: cargo build
       - run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,12 @@ jobs:
       - name: Build release
         run: cargo build --release
       - name: Create Github release
-        uses: softprops/actions-gh-release@v1
+        uses: softprops/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: |
-            target/release/*
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
       - name: Git tag version 
         uses: pkgdeps/git-tag-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,6 @@ jobs:
       - name: Git tag version 
         uses: pkgdeps/git-tag-action@v2
         with:
+          version: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           git_tag_prefix: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup component add rustfmt    
-      - run: cargo fmt -- --check
-        working-directory: ./task-manager
+      - run: cargo fmt --manifest-path Cargo.toml -- --check
       - run: rustup component add clippy
       - run: cargo -- -D warnings
       - run: rustc --version 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup component add rustfmt    
       - run: cargo fmt -- --check
+        working-directory: ./task-manager
       - run: rustup component add clippy
       - run: cargo -- -D warnings
       - run: rustc --version 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: rustup component add rustfmt    
-      - run: cargo fmt --manifest-path Cargo.toml -- --check -X unused_imports
+      - run: cargo fmt --manifest-path Cargo.toml -- --check
       - run: rustup component add clippy
       - run: cargo clippy -- -D warnings
       - run: rustc --version 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: rustup component add rustfmt    
+      - run: cargo fmt -- --chec
+      - run: rustup component add clippy
+      - run: cargo -- -D warnings
       - run: rustc --version 
       - run: cargo build
       - run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: rustup component add rustfmt    
-      # - run: cargo fmt --manifest-path Cargo.toml -- --check
-      - run: cargo fmt --manifest-path Cargo.toml -- --diff
+      - run: cargo fmt --manifest-path Cargo.toml -- --check -X unused_imports
       - run: rustup component add clippy
       - run: cargo clippy -- -D warnings
       - run: rustc --version 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
       - name: Git tag version 
         uses: pkgdeps/git-tag-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,15 @@ on:
     branches:
       - main
       - 'feature/*'
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  metadata: read 
+  id-token: write
 
 jobs:
   tests:
@@ -27,3 +36,20 @@ jobs:
       - run: cargo build
       - run: cargo test
 
+  release:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v3
+      - name: Build release
+        run: cargo build --release
+      - name: Create Github release
+        uses: softprops/actions-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            target/release/*
+      - name: Git tag version 
+        uses: pkgdeps/git-tag-action@v2
+        with:
+          tag: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build release
         run: cargo build --release
       - name: Create Github release
-        uses: softprops/create-release@v1
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,6 @@ jobs:
           tag_name: ${{ github.ref_name }}
           release_name: Release ${{ github.ref_name }}
       - name: Git tag version 
-        uses: pkgdeps/git-tag-action@v2
+        uses: pkgdeps/git-tag-action@v3
         with:
           tag: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: rustup component add rustfmt    
-      - run: cargo fmt --manifest-path Cargo.toml -- --check
+      - run: cargo fmt --manifest-path Cargo.toml -- 
       - run: rustup component add clippy
       - run: cargo clippy -- -D warnings
       - run: rustc --version 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+allow_unused_imports = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-imports_granularity = "Crate"
-report_unused_imports = false

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
-allow_unused_imports = true
+imports_granularity = "Crate"
+report_unused_imports = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,14 +22,14 @@ impl Config {
         } 
 
         let file = fs::File::open(path)
-            .map_err(|e| ConfigError::IoError(e))?;
+            .map_err(ConfigError::IoError)?;
 
-        let mut config: Config = serde_yaml::from_reader(file)
-            .map_err(|e| ConfigError::YamlError(e))?;
+        let config: Config = serde_yaml::from_reader(file)
+            .map_err(ConfigError::YamlError)?;
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map_err(|e| ConfigError::SystemTimeError(e))?
+            .map_err(ConfigError::SystemTimeError)?
             .as_secs();
 
         let new_config = Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@
 use structopt::StructOpt;
 use chrono::{DateTime, Utc};
 use serde::{Serialize, Deserialize};
-use serde_yaml;
-use predicates;
 
 mod tasks;
 mod snippets;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports, dead_code, unused_variables)]
+
 use structopt::StructOpt;
 use chrono::{DateTime, Utc};
 use serde::{Serialize, Deserialize};


### PR DESCRIPTION
### Github Workflow for Test and Release on Push

The branch gets a basic CI Pipeline built for a release strategy and for testing on all pushes

- Initial ci.yml
- Add the ci.yml for github workflows
- Add cargo build in github action
- Add caching of cargo deps and target dir for faster builds
- Correct type in ci.yml
- Add working directory as github actions seems to nest the dir
- Add explicit path for the fmt command
- Add separate step for checkout and cache
- Add to only check the diffs to prevent failing on unused imports
- Add flag to fmt for unused imports
- rustfmt.toml with allow unused imports
- Remove the -X flag that does not exist on fmt
- Update rustfmt.toml to ignore unused imports
- Remove rustfmt.toml and add directive to main to allow unused imports
- Allow formatting of code with fmt
- Remove redundant imports and just passing constructor to .map_err
- Create github action for release with tags
- Add test file to test push tags
- Remove invalid metadata property in ci.yml
- Add official github release action
- Correction of repo for actions create release
- Strip refs/tags prefix from tag and release name in ci.yml
- Update git tag action to v3
- Revert to v2, v3 does not exist and change tag to git_tag_prefix
- Add version for git tag action
- Add property for git commit sha
- Add github_repo input for git tag action
